### PR TITLE
feat: set python indent rules

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -8,3 +8,6 @@ set listchars=tab:▸\ ,eol:¬,space:·
 set cursorcolumn
 set cursorline
 set number
+
+" Set indentation settings specifically for Python
+autocmd FileType python setlocal expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
PEP8: "Use 4 spaces per indentation level."